### PR TITLE
Disable to unselect members who are in the games

### DIFF
--- a/src/components/members/Members.module.css
+++ b/src/components/members/Members.module.css
@@ -14,6 +14,11 @@
   padding: 4px 0;
 }
 
+.MemberListItem {
+  display: flex;
+  align-items: center;
+}
+
 .Checkbox {
   height: 15px;
   margin-left: -18px;
@@ -23,4 +28,9 @@
 
 .Label {
   vertical-align: middle;
+}
+
+.MemberText {
+  margin-left: 4px;
+  font-size: 12px;
 }

--- a/src/components/members/Members.tsx
+++ b/src/components/members/Members.tsx
@@ -8,6 +8,7 @@ interface MembersProps {
   onSelectedMemberIdsChange: (memberId: string) => void;
   selectedMemberIds: Set<string>;
   showElo: boolean;
+  disabledMemberIds: Set<string>;
 }
 
 export default function Members({
@@ -15,6 +16,7 @@ export default function Members({
   onSelectedMemberIdsChange,
   selectedMemberIds,
   showElo,
+  disabledMemberIds,
 }: MembersProps) {
   const members = useStream(membersService.membersStream);
 
@@ -25,13 +27,14 @@ export default function Members({
       </span>
       <ol className={styles.MemberList}>
         {members?.map((member) => (
-          <li key={member.id}>
+          <li key={member.id} className={styles.MemberListItem}>
             {mode === 'select' && (
               <input
                 type="checkbox"
                 id={member.id}
                 className={styles.Checkbox}
                 defaultChecked={selectedMemberIds.has(member.id)}
+                disabled={disabledMemberIds.has(member.id)}
                 onChange={() => {
                   onSelectedMemberIdsChange(member.id);
                 }}
@@ -40,6 +43,9 @@ export default function Members({
             <label className={styles.Label} htmlFor={member.id}>
               {member.name + (showElo ? ' (' + member.elo + ')' : '')}
             </label>
+            {disabledMemberIds.has(member.id) && (
+              <span className={styles.MemberText}>(in-game)</span>
+            )}
           </li>
         ))}
       </ol>

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -18,7 +18,7 @@ export default interface Firebase {
   getAllMembers: () => Promise<Member[]>;
   getMembersById: (ids: string[]) => Promise<Member[]>;
 
-  getSessionMembers: () => Promise<string[]>;
+  getSessionMembersMap: () => Promise<IDBySessionMember>;
   updateSessionMembers: (ids: string[]) => Promise<void>;
   listenToSessionMembers: (
     listener: (sessionMembers: IDBySessionMember) => void

--- a/src/firebase/firebase_impl.ts
+++ b/src/firebase/firebase_impl.ts
@@ -185,12 +185,12 @@ const firebaseImpl: Firebase = {
     }
   },
 
-  async getSessionMembers() {
+  async getSessionMembersMap() {
     maybeInitialize();
     const members: IDBySessionMember =
       (await get(ref(getDatabase(), 'members'))).val() ?? {};
 
-    return Object.keys(members);
+    return members;
   },
 
   listenToSessionMembers(


### PR DESCRIPTION
### Changes
<img width="885" alt="image" src="https://github.com/CubeDr/gmash/assets/24772412/ff62ea17-0f4a-4666-ada1-f18e27d34ce5">

* #9 allows for the removal of members from a session, but an error occurs when the organizer attempts to remove a player who is currently in-game. To prevent this error, it's necessary to disable the option to unselect in-game members. Currently, it's only applied for upcoming game members.
  * TODO: Apply for playing member status.