### PR TITLE
Add elo to the SessionMember field

### DIFF
--- a/src/data/sessionMember.ts
+++ b/src/data/sessionMember.ts
@@ -1,6 +1,7 @@
 export default interface SessionMember {
   played: number;
   upcoming: number;
+  elo: number;
 }
 
 export interface IDBySessionMember {

--- a/src/data/sessionMember.ts
+++ b/src/data/sessionMember.ts
@@ -2,6 +2,7 @@ export default interface SessionMember {
   played: number;
   upcoming: number;
   elo: number;
+  canPlay: boolean;
 }
 
 export interface IDBySessionMember {

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -15,6 +15,7 @@ export default interface Firebase {
   onAuthStateChanged: (callback: (user: User | null) => void) => Unsubscribe;
   register: (id: string, name: string) => Promise<void>;
   getGoogler: (user: User) => Promise<Googler>;
+  updateGoogler: (id: string, elo: number) => Promise<void>;
   getAllMembers: () => Promise<Member[]>;
   getMembersById: (ids: string[]) => Promise<Member[]>;
 

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -44,7 +44,11 @@ export default interface Firebase {
   ) => Unsubscribe;
 
   addGameResult: (win: GameResultTeam, lose: GameResultTeam) => Promise<void>;
-  listenToGameResults: (listener: (gameResults: {win: GameResultTeam, lose: GameResultTeam}[]) => void) => Unsubscribe;
+  listenToGameResults: (
+    listener: (
+      gameResults: { win: GameResultTeam; lose: GameResultTeam }[]
+    ) => void
+  ) => Unsubscribe;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   update: (ref: DatabaseReference, value: any) => Promise<void>;

--- a/src/firebase/firebase_impl.ts
+++ b/src/firebase/firebase_impl.ts
@@ -30,6 +30,7 @@ import {
   query,
   setDoc,
   where,
+  updateDoc,
 } from 'firebase/firestore';
 
 import Member from '../data/member';
@@ -148,6 +149,11 @@ const firebaseImpl: Firebase = {
     };
   },
 
+  async updateGoogler(id: string, elo: number) {
+    maybeInitialize();
+    return await updateDoc(doc(getFirestore(), 'googlers', id), { elo: elo });
+  },
+
   async getAllMembers() {
     maybeInitialize();
     const snapshot = await getDocs(collection(getFirestore(), 'googlers'));
@@ -237,6 +243,11 @@ const firebaseImpl: Firebase = {
       members: Object.keys(members),
       gameResult,
     });
+    await Promise.all(
+      Object.entries(members).map(async ([id, member]) => {
+        await this.updateGoogler(id, member.elo);
+      })
+    );
     await remove(ref(getDatabase(), 'sessionId'));
     await remove(ref(getDatabase(), 'members'));
     await remove(ref(getDatabase(), 'upcoming'));

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import Members from '../../components/members/Members';
-import { IDBySessionMember } from '../../data/sessionMember';
 import firebase from '../../firebase';
 import googlerService from '../../services/googlerService';
 import useStream from '../../useStream';
@@ -35,8 +34,11 @@ export default function HomePage() {
 
   useEffect(() => {
     if (isSessionOpen) {
-      firebase.getSessionMembersMap().then((membersMap: IDBySessionMember) => {
-        setSelectedMemberIds(new Set(Object.keys(membersMap)));
+      firebase.getSessionMembersMap().then((membersMap) => {
+        const canPlayMemberList = Object.keys(membersMap).filter(
+          (key) => membersMap[key].canPlay
+        );
+        setSelectedMemberIds(new Set(canPlayMemberList));
         if (
           googler?.role === 'organizer' &&
           queryParams.get(EDIT_SESSION_QUERY_PARAM) === 'true'

--- a/src/pages/session/useSessionMembers.tsx
+++ b/src/pages/session/useSessionMembers.tsx
@@ -11,14 +11,19 @@ export default function useSelectedMembers() {
 
   useEffect(() => {
     const unsubscribe = firebase.listenToSessionMembers((sessionMemberMap) => {
-      const selected = sessionMemberMap && members
-        ? members
-          .filter((member) => member.id in sessionMemberMap)
-          .map((member) => {
-            const sessionInfo = sessionMemberMap[member.id];
-            return { ...member, ...sessionInfo };
-          })
-        : [];
+      const selected =
+        sessionMemberMap && members
+          ? members
+              .filter(
+                (member) =>
+                  member.id in sessionMemberMap &&
+                  sessionMemberMap[member.id].canPlay
+              )
+              .map((member) => {
+                const sessionInfo = sessionMemberMap[member.id];
+                return { ...member, ...sessionInfo };
+              })
+          : [];
 
       setSessionMembers(selected);
     });


### PR DESCRIPTION
### Changes
* Add elo to the `SessionMember` field
* When we add a new member to the session, get elo from the `googler` db and store the value to the `SessionMember`.
* update `googler`'s elo to the updated elo when session is closed.